### PR TITLE
Add support for building Windows ARM/ARM64 binaries.

### DIFF
--- a/build-native.cmd
+++ b/build-native.cmd
@@ -11,7 +11,9 @@ if [%1] == [] goto Build
 if /i [%1] == [Release] (set BUILD_CONFIG=Release&& shift & goto ArgLoop)
 if /i [%1] == [Debug] (set BUILD_CONFIG=Debug&& shift & goto ArgLoop)
 if /i [%1] == [x64] (set BUILD_ARCH=x64&& shift & goto ArgLoop)
-if /i [%1] == [x86] (set BUILD_ARCH=x86&& set BUILD_CMAKE_GENERATOR_PLATFORM=Win32&&shift & goto ArgLoop)
+if /i [%1] == [ARM64] (set BUILD_ARCH=ARM64&& set BUILD_CMAKE_GENERATOR_PLATFORM=ARM64 && shift & goto ArgLoop)
+if /i [%1] == [ARM] (set BUILD_ARCH=ARM&& set BUILD_CMAKE_GENERATOR_PLATFORM=ARM && shift & goto ArgLoop)
+if /i [%1] == [x86] (set BUILD_ARCH=x86&& set BUILD_CMAKE_GENERATOR_PLATFORM=Win32 && shift & goto ArgLoop)
 shift
 goto ArgLoop
 

--- a/ci-build.cmd
+++ b/ci-build.cmd
@@ -3,5 +3,9 @@
 
 call %~dp0build-native.cmd Release x64
 copy %~dp0cimgui\build\x64\Release\cimgui.dll %~dp0cimgui\build\x64\Release\cimgui.win-x64.dll
+call %~dp0build-native.cmd Release ARM64
+copy %~dp0cimgui\build\ARM64\Release\cimgui.dll %~dp0cimgui\build\ARM64\Release\cimgui.win-ARM64.dll
+call %~dp0build-native.cmd Release ARM
+copy %~dp0cimgui\build\ARM\Release\cimgui.dll %~dp0cimgui\build\ARM\Release\cimgui.win-ARM.dll
 call %~dp0build-native.cmd Release x86
 copy %~dp0cimgui\build\x86\Release\cimgui.dll %~dp0cimgui\build\x86\Release\cimgui.win-x86.dll


### PR DESCRIPTION
As I am using the ImGui.NET library for developing a .NET 5.0 Windows app which can also run on ARM64 I am providing build scripts modified to build ARM64 and ARM targets