### PR TITLE
Updated to 1.89.1 and misc changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,42 +49,42 @@ jobs:
         if: matrix.os == 'windows-latest'
         with:
           name: win-x64
-          path: cimgui\build\x64\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
+          path: cimgui\build\x64\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload win-x86 ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-x86
-          path: cimgui\build\x86\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
+          path: cimgui\build\x86\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload win-arm ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-arm
-          path: cimgui\build\ARM\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
+          path: cimgui\build\ARM\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload win-arm64 ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-arm64
-          path: cimgui\build\ARM64\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
+          path: cimgui\build\ARM64\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload Linux ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-latest'
         with:
           name: linux-x64
-          path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.so
+          path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/*
 
       - name: Upload MacOS ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'macos-latest'
         with:
           name: osx-x64
-          path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dylib
+          path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/*
 
       - name: Upload Definitions Json File
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Submodules
         run: git submodule update --init --recursive
@@ -45,56 +45,56 @@ jobs:
         shell: bash
 
       - name: Upload win-x64 ${{ github.event.inputs.ReleaseType || 'Release' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: win-x64
           path: cimgui\build\x64\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload win-x86 ${{ github.event.inputs.ReleaseType || 'Release' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: win-x86
           path: cimgui\build\x86\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload win-arm ${{ github.event.inputs.ReleaseType || 'Release' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: win-arm
           path: cimgui\build\ARM\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload win-arm64 ${{ github.event.inputs.ReleaseType || 'Release' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: win-arm64
           path: cimgui\build\ARM64\${{ github.event.inputs.ReleaseType || 'Release' }}\*
 
       - name: Upload Linux ${{ github.event.inputs.ReleaseType || 'Release' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'ubuntu-latest'
         with:
           name: linux-x64
           path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/*
 
       - name: Upload MacOS ${{ github.event.inputs.ReleaseType || 'Release' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'macos-latest'
         with:
           name: osx-x64
           path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/*
 
       - name: Upload Definitions Json File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: JsonFiles
           path: cimgui\generator\output\definitions.json
 
       - name: Upload structs_and_enums Json File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: matrix.os == 'windows-latest'
         with:
           name: JsonFiles
@@ -106,7 +106,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: Rename win-x64 and win-x86 artifacts
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      ReleaseType:
+        description: 'Release or Debug'
+        required: true
+        default: 'Release'
 
 jobs:
   Build:
@@ -30,56 +35,56 @@ jobs:
       - name: Get Submodules
         run: git submodule update --init --recursive
 
-      - name: Build
+      - name: Build ${{ github.event.inputs.ReleaseType || 'Release' }}
         run:  |
               if [ "$RUNNER_OS" == "Windows" ]; then
-                ./ci-build.cmd
+                ./ci-build.cmd ${{ github.event.inputs.ReleaseType || 'Release' }}
               else
-                ./ci-build.sh
+                ./ci-build.sh ${{ github.event.inputs.ReleaseType || 'Release' }}
               fi
         shell: bash
 
-      - name: Upload win-x64 Release
+      - name: Upload win-x64 ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-x64
-          path: cimgui\build\x64\Release\cimgui.dll
+          path: cimgui\build\x64\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
 
-      - name: Upload win-x86 Release
+      - name: Upload win-x86 ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-x86
-          path: cimgui\build\x86\Release\cimgui.dll
+          path: cimgui\build\x86\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
 
-      - name: Upload win-arm Release
+      - name: Upload win-arm ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-arm
-          path: cimgui\build\ARM\Release\cimgui.dll
+          path: cimgui\build\ARM\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
 
-      - name: Upload win-arm64 Release
+      - name: Upload win-arm64 ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'windows-latest'
         with:
           name: win-arm64
-          path: cimgui\build\ARM64\Release\cimgui.dll
+          path: cimgui\build\ARM64\${{ github.event.inputs.ReleaseType || 'Release' }}\cimgui.dll
 
-      - name: Upload Linux Release
+      - name: Upload Linux ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-latest'
         with:
           name: linux-x64
-          path: cimgui/build/Release/cimgui.so
+          path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.so
 
-      - name: Upload MacOS Release
+      - name: Upload MacOS ${{ github.event.inputs.ReleaseType || 'Release' }}
         uses: actions/upload-artifact@v2
         if: matrix.os == 'macos-latest'
         with:
           name: osx-x64
-          path: cimgui/build/Release/cimgui.dylib
+          path: cimgui/build/${{ github.event.inputs.ReleaseType || 'Release' }}/cimgui.dylib
 
       - name: Upload Definitions Json File
         uses: actions/upload-artifact@v2

--- a/ci-build.cmd
+++ b/ci-build.cmd
@@ -1,7 +1,8 @@
 @setlocal
 @echo off
+set "RTYPE=%1"
 
-call %~dp0build-native.cmd Release x64
-call %~dp0build-native.cmd Release x86
-call %~dp0build-native.cmd Release ARM64
-call %~dp0build-native.cmd Release ARM
+call %~dp0build-native.cmd %RTYPE% x64
+call %~dp0build-native.cmd %RTYPE% x86
+call %~dp0build-native.cmd %RTYPE% ARM64
+call %~dp0build-native.cmd %RTYPE% ARM

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 scriptPath="`dirname \"$0\"`"
+RTYPE="${1}"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  $scriptPath/build-native.sh release -osx-architectures 'arm64;x86_64'
+  $scriptPath/build-native.sh ${RTYPE} -osx-architectures 'arm64;x86_64'
 else
-  $scriptPath/build-native.sh release
+  $scriptPath/build-native.sh ${RTYPE}
 fi


### PR DESCRIPTION
- Updated to ImGui 1.89.1
- Updated workflow to use `checkout@v3` `upload-artifact@v3` `download-artifact@v3`
- Added ability to trigger a workflow for Debug binaries (default is Release).